### PR TITLE
不应该使用num_frames()而应该使用num_samples()

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -120,7 +120,7 @@ int nsProc(short *input, size_t SampleCount, size_t sampleRate, int num_channels
     NoiseSuppressor ns(cfg, sampleRate, num_channels);
     short *buffer = input;
     bool split_bands = sampleRate > 16000;
-    uint64_t frames = (SampleCount / stream_config.num_frames());
+    uint64_t frames = (SampleCount / stream_config.num_samples());
     for (size_t frame_index = 0; frame_index < frames; ++frame_index) {
         audio.CopyFrom(buffer, stream_config);
         if (split_bands) {
@@ -132,7 +132,7 @@ int nsProc(short *input, size_t SampleCount, size_t sampleRate, int num_channels
             audio.MergeFrequencyBands();
         }
         audio.CopyTo(stream_config, buffer);
-        buffer += stream_config.num_frames();
+        buffer += stream_config.num_samples();
     }
     return 0;
 }


### PR DESCRIPTION
在多声道下他会提取的是 num_frames() * num_channels 去处理,
16K的话处理的是320个;
48K处理的是960个;
PS: 1声道下num_samples() 如 16K自动得160;

验证是我自己写了个测试单元:
  https://github.com/gamefunc/webrtc_NoiseSuppressor_cpp

与直接修改测试:
  int nsProc(short *input, size_t SampleCount, size_t sampleRate, int num_channels) {
      ...
      uint64_t frames = (SampleCount / stream_config.num_samples());
      for (size_t frame_index = 0; frame_index < frames; ++frame_index) {
          ...
          buffer += stream_config.num_samples();
      }
      return 0;
  }
  
  int main() {
      std::string NOISE_WAV_IN_PATH("../../noise_tmoive.wav");    
      std::string DENOISE_WAV_OUT_PATH("../../denoise_tmoive.wav");
      char *in_file = &NOISE_WAV_IN_PATH[0];
      char *out_file = &DENOISE_WAV_OUT_PATH[0];
      uint32_t sampleRate = 0;
      uint64_t nSampleCount = 0;
      uint32_t channels = 1;
      short *data_in = wavRead_s16(...)
      ...
  }